### PR TITLE
Fixed typo with URL parser include

### DIFF
--- a/CRUDAPPGUIDE.MD
+++ b/CRUDAPPGUIDE.MD
@@ -75,7 +75,7 @@ Connect mongoose to mongodb
 ```
 mongoose.connect(
 ‘mongodb://localhost:27017/dbName’, {
-  useNewURLParser: true,
+  useNewUrlParser: true,
   useUnifiedTopology: true,
   useFindAndModify: false
 },


### PR DESCRIPTION
I made this error before - the useNewUrlParser syntax is annoying